### PR TITLE
set relative include headers paths

### DIFF
--- a/src/core/distributions/xmmGaussianDistribution.cpp
+++ b/src/core/distributions/xmmGaussianDistribution.cpp
@@ -31,7 +31,7 @@
  */
 
 #include "xmmGaussianDistribution.hpp"
-#include "xmmMatrix.hpp"
+#include "../common/xmmMatrix.hpp"
 #include <algorithm>
 
 #ifdef WIN32

--- a/src/models/gmm/xmmGmm.cpp
+++ b/src/models/gmm/xmmGmm.cpp
@@ -32,7 +32,7 @@
  */
 
 #include "xmmGmm.hpp"
-#include "xmmKMeans.hpp"
+#include "../kmeans/xmmKMeans.hpp"
 
 xmm::GMM::GMM(bool bimodal) : Model<SingleClassGMM, GMM>(bimodal) {}
 


### PR DESCRIPTION
Hey Jules
This is needed by node-gyp to compile a native xmm addon
This is also needed by ndk-build to compile a .so